### PR TITLE
Update location of cache directory on macOS

### DIFF
--- a/Expedition 01 Redux - The Pioneers/ReadMe.txt
+++ b/Expedition 01 Redux - The Pioneers/ReadMe.txt
@@ -23,7 +23,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 02 Redux - BeachHead/ReadMe.txt
+++ b/Expedition 02 Redux - BeachHead/ReadMe.txt
@@ -22,7 +22,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 03 Redux - Cartographers/ReadMe.txt
+++ b/Expedition 03 Redux - Cartographers/ReadMe.txt
@@ -21,7 +21,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 04 Redux - Emergence/ReadMe.txt
+++ b/Expedition 04 Redux - Emergence/ReadMe.txt
@@ -21,7 +21,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 05 Redux - Exobiology/ReadMe.txt
+++ b/Expedition 05 Redux - Exobiology/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 06 Redux - The Blighted/ReadMe.txt
+++ b/Expedition 06 Redux - The Blighted/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 07 Redux - Leviathan/ReadMe.txt
+++ b/Expedition 07 Redux - Leviathan/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 08 Redux - Polestar/ReadMe.txt
+++ b/Expedition 08 Redux - Polestar/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 09 Redux - Utopia/ReadMe.txt
+++ b/Expedition 09 Redux - Utopia/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 10 - Singularity/ReadMe.txt
+++ b/Expedition 10 - Singularity/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/Expedition 11 - Voyagers/ReadMe.txt
+++ b/Expedition 11 - Voyagers/ReadMe.txt
@@ -20,7 +20,7 @@ b) Then, download the file "SEASON_DATA_CACHE.json" from the cache directory of 
 
 c) Replace the file in your [cache] directory with the one you've just downloaded
 -> Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
--> Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+-> Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 -> MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
 
 d) Restart "No Man's Sky" in offline mode and start a new game "Expedition".

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ So I decided to modify the Hello Games json files and adapt them for my own use 
 - [x] Step 03 : Replace the file in your [cache] directory with the one you've just uploaded
 
 > - 👉🏻 Steam PC : %APPDATA%\HelloGames\NMS\st_{steamId64}\cache
-> - 👉🏻 Steam Mac : ~/Library/Application Support/HelloGames/NMS/st_{64BitSteamID}/cache
+> - 👉🏻 Steam Mac : ~/Library/Application Support/HelloGames/NMS/cache
 > - 👉🏻 MS Store/GOG : %APPDATA%\HelloGames\NMS\NDefaultUser\cache
  
 - [x] Step 04 : Restart "No Man's Sky" in offline mode 


### PR DESCRIPTION
It turns out that on macOS + Steam, the cache directory does not live under the st_[steam_id] directory. So, I've updated the various README files with the correct path.