### PR TITLE
Cartographers Invisible inventory slots

### DIFF
--- a/Expedition 03 Redux - Cartographers/cache/SEASON_DATA_CACHE.json
+++ b/Expedition 03 Redux - Cartographers/cache/SEASON_DATA_CACHE.json
@@ -33,7 +33,7 @@
   ],
   "StartingSuitSlots": 44,
   "StartingSuitTechSlots": 16,
-  "StartingSuitCargoSlots": 16,
+  "StartingSuitCargoSlots": 0,
   "WeaponSeed": [
     false,
     "0x0"


### PR DESCRIPTION
This line was causing 16 invisible inventory slots to spawn in the players inventory. setting this to 0 seems to correct the issue.