### PR TITLE
08 Polestar - Fix broken pirate/civilian models and read-log milestones

### DIFF
--- a/Expedition 08 Redux - Polestar/cache/SEASON_DATA_CACHE.JSON
+++ b/Expedition 08 Redux - Polestar/cache/SEASON_DATA_CACHE.JSON
@@ -128,7 +128,7 @@
   "StartWithFreighter": true,
   "FreighterBaseOverrideFilename": "metadata/simulation/freighterbases/fishparadise.mxml",
   "FreighterRace": {
-    "AlienRace": "None"
+    "AlienRace": "Traders"
   },
   "StartAboardFreighter": true,
   "ValidSpawnBuildings": [


### PR DESCRIPTION
I don't know why this works, but it does.  The freighter is now a regular civilian freighter and the captain has the dialog option to Read Logs.

I haven't finished the playthough, but it's working so far.

I picked "Traders" because they were in the first video I found online.  I didn't any others.  